### PR TITLE
Specify the number of healthCheck retries

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -274,6 +274,7 @@ resource "aws_ecs_task_definition" "background_worker" {
       "command": [ "CMD-SHELL", "ps ax | grep -v grep | grep simple-rainbow" ],
       "interval": 10,
       "timeout": 5,
+      "retries": 3,
       "startPeriod": 10
     },
     "logConfiguration": {


### PR DESCRIPTION
If we don't specify the number of health check retries, `aws_ecs_task_definition` resource will be recreated when `terraform plan` is executed.